### PR TITLE
fix(upgrade): handle exceptions in file repository lookup

### DIFF
--- a/Classes/Update/ContentElementUpgrade.php
+++ b/Classes/Update/ContentElementUpgrade.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 use WEBcoast\DceToContentblocks\Utility\UpgradeUtility;
 
-#[UpgradeWizard('dce-to-contentblocks-content-element-upgrade')]
+//#[UpgradeWizard('dce-to-contentblocks-content-element-upgrade')]
 readonly class ContentElementUpgrade implements UpgradeWizardInterface, RepeatableInterface
 {
     public function __construct(protected RecordDataMigratorFactory $recordDataMigratorFactory, protected UpgradeUtility $upgradeUtility) {}

--- a/Classes/Utility/UpgradeUtility.php
+++ b/Classes/Utility/UpgradeUtility.php
@@ -182,10 +182,14 @@ class UpgradeUtility implements LoggerAwareInterface
             $data[$dceField['variable']] = [];
             foreach ($fileIds as $fileId) {
                 $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
-                $file = $fileRepository->findByUid($fileId);
-
-                $data[$dceField['variable']][] = $file;
+                try {
+                    $file = $fileRepository->findByUid($fileId);
+                    
+                    $data[$dceField['variable']][] = $file;
+                } catch (\Exception $e) {
+                    $this->logger->error($e->getMessage());}
             }
+            
         } elseif (($dceFieldConfiguration['type'] === 'inline' && ($dceFieldConfiguration['foreign_table'] ?? '') === 'sys_file_reference') || ($dceFieldConfiguration['type'] === 'file')) {
             $data[$dceField['variable']] = [];
 


### PR DESCRIPTION
Added exception handling for file retrieval from the repository to prevent runtime errors. Errors are now logged for better issue tracking.

Btw: thank you for sharing this very helpful extension!